### PR TITLE
Add clear filters button to search pages

### DIFF
--- a/src/app/(light)/explorer/components/search-filters/clear-filters-button.tsx
+++ b/src/app/(light)/explorer/components/search-filters/clear-filters-button.tsx
@@ -1,0 +1,32 @@
+import { common } from '@/locale/en/common';
+
+import { Close } from '@mui/icons-material';
+import { Button } from '@mui/material';
+
+type Props = {
+  onClear: () => void;
+};
+
+export default function ClearFiltersButton({ onClear }: Props) {
+  return (
+    <Button
+      onClick={onClear}
+      startIcon={<Close />}
+      variant="outlined"
+      color="inherit"
+      sx={{
+        order: {
+          xs: 999,
+          lg: 'unset',
+        },
+        borderWidth: {
+          xs: 1,
+          lg: 0,
+        },
+      }}
+      size="large"
+    >
+      {common.actions.clear_filters}
+    </Button>
+  );
+}

--- a/src/app/(light)/explorer/components/search-filters/search-filters.tsx
+++ b/src/app/(light)/explorer/components/search-filters/search-filters.tsx
@@ -52,7 +52,7 @@ export default function SearchFilters({
             }}
             alignItems={{
               xs: 'stretch',
-              lg: 'flex-start',
+              lg: 'center',
             }}
             gap={1}
           >

--- a/src/app/(light)/explorer/data-models/components/search/search.tsx
+++ b/src/app/(light)/explorer/data-models/components/search/search.tsx
@@ -8,6 +8,7 @@ import { useDebouncedState } from '@react-hookz/web';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import DataModelExplorerCard from '../../../components/data-model-card/data-model-card';
+import ClearFiltersButton from '../../../components/search-filters/clear-filters-button';
 import SortByField, {
   SortByOption,
 } from '../../../components/search-filters/sort-by-field';
@@ -109,6 +110,17 @@ export default function DataModelsExplorerSearch() {
   const dataModels =
     dataModelsQuery.data?.pages?.flatMap(({ dataModels }) => dataModels) ?? [];
 
+  const isFiltering =
+    selectedTags.length > 0 ||
+    selectedConsumptionPrice.length > 0 ||
+    selectedAmountOfIssuances.length > 0;
+
+  const onClearFilters = () => {
+    setSelectedTags([]);
+    setSelectedConsumptionPrice([]);
+    setSelectedAmountOfIssuances([]);
+  };
+
   const filters = (
     <>
       <TagsField
@@ -131,6 +143,7 @@ export default function DataModelsExplorerSearch() {
         setAmountOfIssuances={setSelectedAmountOfIssuances}
         isLoading={metadata.isLoading}
       />
+      {isFiltering && <ClearFiltersButton onClear={onClearFilters} />}
       <SortByField
         selectedSort={undefined}
         onSort={() => {}}

--- a/src/app/(light)/explorer/request-templates/components/search/search.tsx
+++ b/src/app/(light)/explorer/request-templates/components/search/search.tsx
@@ -7,6 +7,7 @@ import { useDebouncedState } from '@react-hookz/web';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import RequestTemplateExplorerCard from '../../../components/request-template-card/request-template-card';
+import ClearFiltersButton from '../../../components/search-filters/clear-filters-button';
 import SortByField, {
   SortByOption,
 } from '../../../components/search-filters/sort-by-field';
@@ -55,6 +56,9 @@ export default function DataModelsRequestExplorerSearch() {
       ({ dataRequestTemplates }) => dataRequestTemplates
     ) ?? [];
 
+  const isFiltering = false;
+  const onClearFilters = () => {};
+
   const filters = (
     <>
       <TagsField tags={[]} setTags={() => {}} />
@@ -70,6 +74,7 @@ export default function DataModelsRequestExplorerSearch() {
         min={0}
         max={100}
       />
+      {isFiltering && <ClearFiltersButton onClear={onClearFilters} />}
       <SortByField
         selectedSort={undefined}
         onSort={() => {}}

--- a/src/locale/en/common.ts
+++ b/src/locale/en/common.ts
@@ -67,6 +67,7 @@ export const common = {
     view_pda: 'View PDA',
     view_proof: 'View Proof',
     subscribe: 'Subscribe',
+    clear_filters: 'Clear filters',
   },
   socials: {
     twitter: 'Twitter',


### PR DESCRIPTION
This pull request adds a clear filters button to the search pages of the Data Models Explorer and Data Models Request Explorer.