### PR TITLE
Add explorer link and sandbox menu item

### DIFF
--- a/src/app/(landing)/components/header/index.tsx
+++ b/src/app/(landing)/components/header/index.tsx
@@ -11,6 +11,7 @@ import useMobileDetect from '@/app/(landing)/hooks/use-mobile.detect';
 import { joinClasses } from '@/app/(landing)/utils/function';
 import externalLinks from '@/constants/externalLinks';
 import routes from '@/constants/routes';
+import { currentEnv } from '@/utils/env';
 import { useLenis } from '@studio-freight/react-lenis';
 
 import { Stack, Typography } from '@mui/material';
@@ -128,9 +129,15 @@ export default function Header() {
                 </Link>
                 <Link
                   className={styles.link}
-                  href={externalLinks.gateway_sandbox}
+                  href={
+                    currentEnv() === 'production'
+                      ? externalLinks.gateway_sandbox
+                      : externalLinks.gateway
+                  }
                 >
-                  <Button variant="text">Sandbox</Button>
+                  <Button variant="text">
+                    {currentEnv() === 'production' ? 'Sandbox' : 'Mainnet'}
+                  </Button>
                 </Link>
               </div>
 
@@ -181,11 +188,17 @@ export default function Header() {
             </Link>
             <Link
               className={styles.mobile_link}
-              href={externalLinks.gateway_sandbox}
+              href={
+                currentEnv() === 'production'
+                  ? externalLinks.gateway_sandbox
+                  : externalLinks.gateway
+              }
               onClick={() => setBurgerActive(false)}
             >
               <Button variant="text">
-                <span>Sandbox</span>
+                <span>
+                  {currentEnv() === 'production' ? 'Sandbox' : 'Mainnet'}
+                </span>
                 <ArrowRight2 className={styles.mobile_link_arrow} />
               </Button>
             </Link>

--- a/src/app/(landing)/components/header/index.tsx
+++ b/src/app/(landing)/components/header/index.tsx
@@ -9,6 +9,7 @@ import { useHeaderContext } from '@/app/(landing)/contexts/header-context';
 import { useIsFirstRender } from '@/app/(landing)/hooks/use-is-first-render';
 import useMobileDetect from '@/app/(landing)/hooks/use-mobile.detect';
 import { joinClasses } from '@/app/(landing)/utils/function';
+import externalLinks from '@/constants/externalLinks';
 import routes from '@/constants/routes';
 import { useLenis } from '@studio-freight/react-lenis';
 
@@ -125,6 +126,12 @@ export default function Header() {
                 <Link className={styles.link} href="/build">
                   <Button variant="text">Build</Button>
                 </Link>
+                <Link
+                  className={styles.link}
+                  href={externalLinks.gateway_sandbox}
+                >
+                  <Button variant="text">Sandbox</Button>
+                </Link>
               </div>
 
               <div className={styles.buttons_container}>
@@ -169,6 +176,16 @@ export default function Header() {
             >
               <Button variant="text">
                 <span>Build</span>
+                <ArrowRight2 className={styles.mobile_link_arrow} />
+              </Button>
+            </Link>
+            <Link
+              className={styles.mobile_link}
+              href={externalLinks.gateway_sandbox}
+              onClick={() => setBurgerActive(false)}
+            >
+              <Button variant="text">
+                <span>Sandbox</span>
                 <ArrowRight2 className={styles.mobile_link_arrow} />
               </Button>
             </Link>

--- a/src/app/(landing)/components/header/index.tsx
+++ b/src/app/(landing)/components/header/index.tsx
@@ -128,6 +128,9 @@ export default function Header() {
               </div>
 
               <div className={styles.buttons_container}>
+                <Link href="/explorer">
+                  <Button variant="outlined">Explorer</Button>
+                </Link>
                 <Link href="/login">
                   <Button
                     variant="contained"
@@ -166,6 +169,16 @@ export default function Header() {
             >
               <Button variant="text">
                 <span>Build</span>
+                <ArrowRight2 className={styles.mobile_link_arrow} />
+              </Button>
+            </Link>
+            <Link
+              className={styles.mobile_link}
+              href="/explorer"
+              onClick={() => setBurgerActive(false)}
+            >
+              <Button variant="text">
+                <span>Explorer</span>
                 <ArrowRight2 className={styles.mobile_link_arrow} />
               </Button>
             </Link>

--- a/src/app/(landing)/components/landing-footer/links-footer.ts
+++ b/src/app/(landing)/components/landing-footer/links-footer.ts
@@ -33,7 +33,7 @@ export const linksSocial = [
   },
 ];
 
-export const linksList = [
+export const linksList: { title: string; href: string; target: string }[] = [
   {
     title: 'Learn',
     href: routes.learn,
@@ -42,6 +42,11 @@ export const linksList = [
   {
     title: 'Build',
     href: routes.build,
+    target: '_self',
+  },
+  {
+    title: 'Explorer',
+    href: routes.explorer.root,
     target: '_self',
   },
   {
@@ -62,7 +67,6 @@ export const linksList = [
     href: `${DOCS_BASE_URL}docs/privacy-security-standards`,
     target: '_blank',
   },
-
   {
     title: 'Brand Kit',
     href: externalLinks.gateway_brandkit,

--- a/src/app/(light)/login/components/sections/initial/initial.tsx
+++ b/src/app/(light)/login/components/sections/initial/initial.tsx
@@ -1,4 +1,5 @@
 import { TitleSubtitleField } from '@/components/title-field/title-field';
+import documentationRoutes from '@/constants/documentationRoutes';
 import EvmProvider from '@/context/evm-provider/evm-provider';
 import SolanaProvider from '@/context/solana-provider';
 import { auth } from '@/locale/en/auth';
@@ -26,7 +27,11 @@ export function AuthenticationInitial() {
       </EvmProvider>
       <Typography color="text.secondary" variant="caption">
         {auth.steps.initial.terms_info}{' '}
-        <Link href="/terms" underline="none">
+        <Link
+          href={documentationRoutes.termsOfService}
+          target="_blank"
+          underline="none"
+        >
           {auth.steps.initial.terms_of_service}{' '}
         </Link>
       </Typography>

--- a/src/constants/documentationRoutes.js
+++ b/src/constants/documentationRoutes.js
@@ -9,6 +9,7 @@ const documentationRoutes = {
   dataRequest: 'https://docs.mygateway.xyz/docs/data-request',
   startIssuing: 'https://docs.mygateway.xyz/docs/start-issuing',
   startVerifying: 'https://docs.mygateway.xyz/docs/start-verifying',
+  termsOfService: 'https://docs.mygateway.xyz/docs/terms-of-service',
 };
 
 module.exports = documentationRoutes;


### PR DESCRIPTION
This pull request adds an explorer link to the header and a sandbox menu item. The explorer link allows users to navigate to the explorer page, while the sandbox menu item provides a link to the sandbox or mainnet based on the current environment. These additions enhance the user experience and improve navigation within the application.

Fixes #DEV-256