### PR TITLE
Hide routes on testnet

### DIFF
--- a/src/app/(light)/dashboard/user/components/dashboard-user-menu-items.tsx
+++ b/src/app/(light)/dashboard/user/components/dashboard-user-menu-items.tsx
@@ -5,6 +5,7 @@ import DataRequestOutlinedIcon from '@/components/icons/data-request-outlined';
 import DataRequestTemplateOutlinedIcon from '@/components/icons/data-request-template-outlined';
 import { GTWMenuItemSettings } from '@/components/menu-item/menu-item';
 import routes from '@/constants/routes';
+import { isSandbox } from '@/utils/env';
 
 import { ExploreOutlined, HomeOutlined } from '@mui/icons-material';
 
@@ -41,6 +42,7 @@ export const dashboardUserMenuItems: GTWMenuItemSettings[] = [
     ],
     icon: DataRequestOutlinedIcon,
     navbar: true,
+    hide: !isSandbox,
   },
   {
     name: 'Data Proofs',
@@ -51,12 +53,14 @@ export const dashboardUserMenuItems: GTWMenuItemSettings[] = [
       routes.dashboard.user.proof(''),
     ],
     icon: DataProofOutlinedIcon,
+    hide: !isSandbox,
   },
   {
     name: 'Data Models',
     href: routes.dashboard.user.myDataModels,
     activeHrefs: [routes.dashboard.user.myDataModels],
     icon: DataModelOutlinedIcon,
+    hide: !isSandbox,
   },
   {
     name: 'Request Templates',
@@ -66,6 +70,7 @@ export const dashboardUserMenuItems: GTWMenuItemSettings[] = [
       routes.dashboard.user.networkRequestTemplates,
     ],
     icon: DataRequestTemplateOutlinedIcon,
+    hide: !isSandbox,
   },
   {
     name: 'Explorer',
@@ -74,6 +79,6 @@ export const dashboardUserMenuItems: GTWMenuItemSettings[] = [
     icon: ExploreOutlined,
     externalLink: true,
   },
-];
+].filter((item) => !item.hide);
 
 export default dashboardUserMenuItems;

--- a/src/app/(light)/dashboard/user/data-models/layout.tsx
+++ b/src/app/(light)/dashboard/user/data-models/layout.tsx
@@ -1,3 +1,4 @@
+import { redirect } from 'next/navigation';
 import { PropsWithChildren } from 'react';
 
 import HelpContentCard from '@/components/help-content-card/help-content-card';
@@ -10,10 +11,14 @@ import {
   CONTAINER_PX,
   NEGATIVE_CONTAINER_PX,
 } from '@/theme/config/style-tokens';
+import { isSandbox } from '@/utils/env';
 
 import { Box } from '@mui/material';
 
 export default function DataModelsLayout({ children }: PropsWithChildren) {
+  if (!isSandbox) {
+    redirect(routes.dashboard.user.home);
+  }
   return (
     <Box sx={{ py: 2 }}>
       <TitleLayout

--- a/src/app/(light)/dashboard/user/proof/[id]/page.tsx
+++ b/src/app/(light)/dashboard/user/proof/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import { redirect } from 'next/navigation';
 
 import BackButton from '@/components/buttons/back-button/back-button';
 import TopBarContainer from '@/components/containers/top-bar-container/top-bar-container';
@@ -7,6 +8,7 @@ import routes from '@/constants/routes';
 import { getGtwServerSession } from '@/services/next-auth/get-gtw-server-session';
 import { getPrivateApi } from '@/services/protocol/api';
 import { Proof } from '@/services/protocol/types';
+import { isSandbox } from '@/utils/env';
 
 import ProofItem from './components/proof-item';
 
@@ -36,6 +38,10 @@ export default async function ProofPage({
 }: {
   params: { id: string };
 }) {
+  if (!isSandbox) {
+    redirect(routes.dashboard.user.home);
+  }
+
   const session = await getGtwServerSession();
   const userId = session?.user.id;
   const proof = await getProof(params.id);

--- a/src/app/(light)/dashboard/user/proofs/layout.tsx
+++ b/src/app/(light)/dashboard/user/proofs/layout.tsx
@@ -1,3 +1,4 @@
+import { redirect } from 'next/navigation';
 import { PropsWithChildren } from 'react';
 
 import HelpContentCard from '@/components/help-content-card/help-content-card';
@@ -11,10 +12,14 @@ import {
   CONTAINER_PX,
   NEGATIVE_CONTAINER_PX,
 } from '@/theme/config/style-tokens';
+import { isSandbox } from '@/utils/env';
 
 import { Box } from '@mui/system';
 
 export default function DataProofsLayout({ children }: PropsWithChildren) {
+  if (!isSandbox) {
+    redirect(routes.dashboard.user.home);
+  }
   return (
     <Box sx={{ py: 2 }}>
       <TitleLayout

--- a/src/app/(light)/dashboard/user/request-templates/layout.tsx
+++ b/src/app/(light)/dashboard/user/request-templates/layout.tsx
@@ -1,3 +1,4 @@
+import { redirect } from 'next/navigation';
 import { PropsWithChildren } from 'react';
 
 import { InstructionGuide } from '@/components/instruction-guide/instruction-guide';
@@ -12,12 +13,16 @@ import {
   CONTAINER_PX,
   NEGATIVE_CONTAINER_PX,
 } from '@/theme/config/style-tokens';
+import { isSandbox } from '@/utils/env';
 
 import { Box } from '@mui/material';
 
 export default function DataRequestTeampltesLayout({
   children,
 }: PropsWithChildren) {
+  if (!isSandbox) {
+    redirect(routes.dashboard.user.home);
+  }
   return (
     <Box sx={{ py: 2 }}>
       <TitleLayout

--- a/src/app/(light)/dashboard/user/request/[id]/page.tsx
+++ b/src/app/(light)/dashboard/user/request/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import { Session } from 'next-auth';
+import { redirect } from 'next/navigation';
 
 import BackButton from '@/components/buttons/back-button/back-button';
 import TopBarContainer from '@/components/containers/top-bar-container/top-bar-container';
@@ -22,6 +23,7 @@ import {
 import { NEGATIVE_CONTAINER_PX } from '@/theme/config/style-tokens';
 import { PageProps } from '@/types/next';
 import { getSessionOrg } from '@/utils/currentOrg';
+import { isSandbox } from '@/utils/env';
 import { limitCharsCentered } from '@/utils/string';
 import dayjs from 'dayjs';
 import { PartialDeep } from 'type-fest';
@@ -85,6 +87,9 @@ export async function generateMetadata({
 export default async function DashboardUserDataRequest({
   params: { id, username },
 }: PageProps<{ id: string; username?: string }>) {
+  if (!isSandbox) {
+    redirect(routes.dashboard.user.home);
+  }
   const session = (await getGtwServerSession()) as Session;
   const userId = session.user.id;
   const dataRequest = await getDataRequest(id);

--- a/src/app/(light)/dashboard/user/requests/layout.tsx
+++ b/src/app/(light)/dashboard/user/requests/layout.tsx
@@ -1,14 +1,20 @@
+import { redirect } from 'next/navigation';
 import { PropsWithChildren } from 'react';
 
 import { InstructionGuide } from '@/components/instruction-guide/instruction-guide';
 import TitleLayout from '@/components/title-layout/title-layout';
 import { instructionGuideKeys } from '@/constants/instruction-guide';
+import routes from '@/constants/routes';
 import { instructionGuide } from '@/locale/en/educational';
 import { requests } from '@/locale/en/request';
+import { isSandbox } from '@/utils/env';
 
 import { Box } from '@mui/material';
 
 export default function DataRequestsLayout({ children }: PropsWithChildren) {
+  if (!isSandbox) {
+    redirect(routes.dashboard.user.home);
+  }
   return (
     <Box sx={{ py: 2 }}>
       <TitleLayout

--- a/src/components/menu-item/menu-item.tsx
+++ b/src/components/menu-item/menu-item.tsx
@@ -20,6 +20,7 @@ type Props = {
   activeIcon?: FC<SvgIconProps>;
   navbar?: boolean;
   externalLink?: boolean;
+  hide?: boolean;
 };
 
 export type GTWMenuItemSettings = Props & {


### PR DESCRIPTION
This PR adds a new feature to hide certain routes on the testnet environment. It includes changes to the dashboard user menu items and data models layout.