### PR TITLE
Rename 'data proof' to 'shared data'

### DIFF
--- a/e2e/tests/proof.spec.ts
+++ b/e2e/tests/proof.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page } from '@playwright/test';
 
-test.describe('Data proof', async () => {
+test.describe('Shared Data', async () => {
   let sharedPage: Page;
   let name: string;
   test.beforeAll(async ({ browser }) => {

--- a/e2e/tests/received-proofs.spec.ts
+++ b/e2e/tests/received-proofs.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page } from '@playwright/test';
 
-test.describe('Received Data proofs', async () => {
+test.describe('Received Shared Datas', async () => {
   let sharedPage: Page;
   test.beforeAll(async ({ browser }) => {
     const context = await browser.newContext();

--- a/e2e/tests/sent-proofs.spec.ts
+++ b/e2e/tests/sent-proofs.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page } from '@playwright/test';
 
-test.describe('Sent Data proofs', async () => {
+test.describe('Sent Shared Datas', async () => {
   let sharedPage: Page;
   test.beforeAll(async ({ browser }) => {
     const context = await browser.newContext();

--- a/src/app/(light)/dashboard/org/[username]/proof/[id]/page.tsx
+++ b/src/app/(light)/dashboard/org/[username]/proof/[id]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const proof = await getProof(params.id);
   return {
-    title: `Data Proof ${proof?.id} - Gateway Network`,
+    title: `Shared Data ${proof?.id} - Gateway Network`,
   };
 }
 

--- a/src/app/(light)/dashboard/org/[username]/proofs/received/page.tsx
+++ b/src/app/(light)/dashboard/org/[username]/proofs/received/page.tsx
@@ -13,7 +13,7 @@ import OrganizationProofsReceivedTable from './components/org-proofs-received-ta
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
-    title: 'Received Data Proofs - Gateway Network',
+    title: 'Shared Data with the Org - Gateway Network',
   };
 }
 

--- a/src/app/(light)/dashboard/org/components/dashboard-org-menu-items.tsx
+++ b/src/app/(light)/dashboard/org/components/dashboard-org-menu-items.tsx
@@ -40,7 +40,7 @@ export const dashboardOrgMenuItems = (
     navbar: true,
   },
   {
-    name: 'Received Data Proofs',
+    name: 'Shared Data',
     href: routes.dashboard.org.receivedProofs(username),
     activeHrefs: [routes.dashboard.org.receivedProofs(username)],
     icon: DataProofOutlinedIcon,

--- a/src/app/(light)/dashboard/user/components/dashboard-user-menu-items.tsx
+++ b/src/app/(light)/dashboard/user/components/dashboard-user-menu-items.tsx
@@ -21,7 +21,7 @@ export const dashboardUserMenuItems: GTWMenuItemSettings[] = [
     navbar: true,
   },
   {
-    name: 'Data Assets',
+    name: 'My Data',
     href: routes.dashboard.user.receivedAssets,
     activeHrefs: [
       routes.dashboard.user.receivedAssets,
@@ -45,7 +45,7 @@ export const dashboardUserMenuItems: GTWMenuItemSettings[] = [
     hide: !isSandbox,
   },
   {
-    name: 'Data Proofs',
+    name: 'Shared Data',
     href: routes.dashboard.user.receivedProofs,
     activeHrefs: [
       routes.dashboard.user.receivedProofs,

--- a/src/app/(light)/dashboard/user/proofs/received/page.tsx
+++ b/src/app/(light)/dashboard/user/proofs/received/page.tsx
@@ -11,7 +11,7 @@ import ProofsReceivedTable from './components/proofs-received-table';
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
-    title: 'Received Data Proofs - Gateway Network',
+    title: 'Shared Data - Gateway Network',
   };
 }
 

--- a/src/app/(light)/dashboard/user/proofs/sent/page.tsx
+++ b/src/app/(light)/dashboard/user/proofs/sent/page.tsx
@@ -11,7 +11,7 @@ import ProofsSentTable from './components/proofs-sent-table';
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
-    title: 'Sent Data Proofs - Gateway Network',
+    title: 'Sent Shared Datas - Gateway Network',
   };
 }
 

--- a/src/app/(light)/dashboard/user/request/[id]/components/request-card.tsx
+++ b/src/app/(light)/dashboard/user/request/[id]/components/request-card.tsx
@@ -58,7 +58,7 @@ export default function RequestCard({
     mutationFn: (data: Create_Proof_From_RequestMutationVariables) => {
       return privateApi?.create_proof_from_request(data);
     },
-    onMutate: () => setLoadingText('Data Proof is being processed...'),
+    onMutate: () => setLoadingText('Shared Data is being processed...'),
     onSuccess: () => {
       sendEvent('accept_request');
       router.refresh();

--- a/src/locale/en/common.ts
+++ b/src/locale/en/common.ts
@@ -41,7 +41,7 @@ export const common = {
     reject: 'Reject',
     save: 'Save',
     cancel: 'Cancel',
-    check_data_proof: 'Check data proof',
+    check_data_proof: 'Check shared data',
     share_now: 'Share now',
     share_a_copy: 'Share a copy',
     revoke_access: 'Revoke access',

--- a/src/locale/en/home.ts
+++ b/src/locale/en/home.ts
@@ -57,7 +57,7 @@ export const home = {
     {
       icon: DataAssetIcon,
       heading: 'Manage',
-      title: 'Check Your Data Proofs',
+      title: 'Check Your Shared Datas',
       subtitle:
         'Review what data assets you have shared, to who, and if you want to remove access.',
       btn_text: 'View All',

--- a/src/locale/en/pda.ts
+++ b/src/locale/en/pda.ts
@@ -18,7 +18,7 @@ export const pda = {
   shared_with: {
     shared_with: 'Shared with',
     verifier: 'Verifier',
-    data_proof_id: 'Data proof ID',
+    data_proof_id: 'Shared Data ID',
   },
   activities: {
     issued: 'PDA issued',

--- a/src/locale/en/pda.ts
+++ b/src/locale/en/pda.ts
@@ -53,7 +53,7 @@ export const pda = {
 export const pdas = {
   empty: 'No data assets yet',
   load_more: 'load more',
-  my_data_assets: 'Data Assets',
+  my_data_assets: 'My Data',
   data_asset: 'Data asset',
   recipient: 'Recipient',
   status: 'Status',

--- a/src/locale/en/proof.ts
+++ b/src/locale/en/proof.ts
@@ -13,16 +13,16 @@ export const proof = {
   share: {
     data_shared_with: 'Shared with',
     data_shared_by: 'Shared by',
-    data_proof_id: 'Data Proof ID',
+    data_proof_id: 'Shared data ID',
     data_asset_shared: 'Data asset shared',
   },
 };
 
 export const proofs = {
-  empty: 'No data proofs yet',
-  data_proofs: 'Data proofs',
+  empty: 'No shared datas yet',
+  data_proofs: 'Shared Data',
   data_proofs_subtitle:
-    'These are the copies of data proofs that you have sent and that have been sent to you',
+    'These are the copies of shared datas that you have sent and that have been sent to you',
   owner: 'Owners',
   verifier: 'Verifier',
   sender: 'Senders',
@@ -30,14 +30,14 @@ export const proofs = {
   request_template_id: 'Request template ID',
   share_date: 'Share date',
   data_amount: 'Data amount',
-  received_proofs: 'Data Proofs Received',
+  received_proofs: 'Received Shared Datas',
   received_proofs_subtitle:
     'These are the copies of data assets that have been sent to you',
 };
 
 export const helperContent = {
-  title: 'Share your data with Data Proofs',
-  desc: 'Data Proofs facilitate data exchange in a secure, user-consented, and privacy preserving manner. Proofs can be shared to Verifiers or anyone you want to have access to your information.',
+  title: 'Share your data',
+  desc: 'Shared Datas facilitate data exchange in a secure, user-consented, and privacy preserving manner. Proofs can be shared to Verifiers or anyone you want to have access to your information.',
   btnText: 'Learn how',
   btnLink: documentationRoutes.proof,
 };

--- a/src/locale/en/proof.ts
+++ b/src/locale/en/proof.ts
@@ -13,7 +13,7 @@ export const proof = {
   share: {
     data_shared_with: 'Shared with',
     data_shared_by: 'Shared by',
-    data_proof_id: 'Shared data ID',
+    data_proof_id: 'Shared Data ID',
     data_asset_shared: 'Data asset shared',
   },
 };

--- a/src/locale/en/transaction.ts
+++ b/src/locale/en/transaction.ts
@@ -55,7 +55,7 @@ export const financial_transaction_actions = {
   out: {
     request_cost: 'Request cost',
     withdraw: 'Money withdraw',
-    proof_share: 'Data proof sharing',
+    proof_share: 'Private Data sharing',
     pda_issuance: 'PDA issuance cost',
     pda_update: 'PDA update cost',
     pda_status_change: 'PDA status change cost',

--- a/src/locale/en/transaction.ts
+++ b/src/locale/en/transaction.ts
@@ -55,7 +55,7 @@ export const financial_transaction_actions = {
   out: {
     request_cost: 'Request cost',
     withdraw: 'Money withdraw',
-    proof_share: 'Private Data sharing',
+    proof_share: 'Shared Data',
     pda_issuance: 'PDA issuance cost',
     pda_update: 'PDA update cost',
     pda_status_change: 'PDA status change cost',


### PR DESCRIPTION
This PR renames all instances of 'data proof' to 'shared data' in the codebase. This change improves clarity and consistency in the naming of data assets.

And renames some instances of "Data asset" to "My data" on user views